### PR TITLE
Use Kotlin 2.3.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
 
 [versions]
-kotlin-version = "2.4.0"
+kotlin-version = "2.3.21"
 kotlin-json = "1.11.0"
 
 [libraries]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin version to 2.3.21, which affects the Kotlin Gradle plugin and Kotlin serialization tooling used in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->