### PR TITLE
Added HttpUser property shareConnections

### DIFF
--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -42,6 +42,11 @@ public class HttpUser_RestClient extends TulipUser {
         var readTimeout_ = getUserParamValue("readTimeoutMillis");
         var httpVersion_ = getUserParamValue("httpVersion").toUpperCase();
 
+        var shareConnections_ = getUserParamValue("shareConnections");
+        if (!shareConnections_.isEmpty()) {
+            shareConnections = Boolean.parseBoolean(shareConnections_);
+        }
+
         if (url_.isEmpty()) {
             logger().error("\"url\" property is empty");
             return false;
@@ -154,7 +159,12 @@ public class HttpUser_RestClient extends TulipUser {
      * @return RestClient
      */
     public RestClient restClient() {
-        return https[getUserId() % https.length].restClient;
+        if (shareConnections) {
+            return https[getUserId() % https.length].restClient;
+        } else {
+            throw new RuntimeException(
+                    "RestClient is not shared, please create a new RestClient for each request.");
+        }
     }
 
     // RestClient objects
@@ -210,4 +220,11 @@ public class HttpUser_RestClient extends TulipUser {
 
     /** HTTP header key value */
     public static String http_header_val = "";
+
+    /** Whether to share connections
+     * If false, then each user will be allocated its own
+     * restClient object. This is required when using
+     * httpOnly cookies to user JWTs that contain the userId.
+     */
+    public static boolean shareConnections = true;
 }

--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.RestClient;
 
 class HttpRecord {
     public RestClient restClient = null;
+    public HttpClient httpClient = null;
     public String url = "";
     public String urlProtocol = "";
     public String urlHost = "";
@@ -18,6 +19,13 @@ class HttpRecord {
     public String urlPath = "";
     public String urlQuery = "";
 }
+
+record RestClientRecord(RestClient restClient, HttpClient httpClient) {
+    public RestClientRecord() {
+        this(null, null);
+    }
+}
+;
 
 /** The HttpUser class. */
 public class HttpUser_RestClient extends TulipUser {
@@ -57,8 +65,9 @@ public class HttpUser_RestClient extends TulipUser {
         int idx = 0;
         for (String url : urls) {
             https[idx] = new HttpRecord();
-            https[idx].restClient =
-                    createRestClient(idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
+            var rh = createRestClient(idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
+            https[idx].restClient = rh.restClient();
+            https[idx].httpClient = rh.httpClient();
             idx += 1;
         }
 
@@ -82,7 +91,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @param httpVersion_
      * @return
      */
-    RestClient createRestClient(
+    RestClientRecord createRestClient(
             int idx,
             String url_,
             String connectTimeout_,
@@ -141,7 +150,7 @@ public class HttpUser_RestClient extends TulipUser {
             logger().info("[{}]readTimeoutMillis={}", idx, readTimeout_);
         }
         restClient = RestClient.builder().requestFactory(factory).baseUrl(baseUrl).build();
-        return restClient;
+        return new RestClientRecord(restClient, httpClient);
     }
 
     /**
@@ -150,6 +159,13 @@ public class HttpUser_RestClient extends TulipUser {
      * @return boolean
      */
     public boolean onStop() {
+        if (shareConnections) {
+            for (HttpRecord hr : https) {
+                if (hr.httpClient != null) {
+                    hr.httpClient.close();
+                }
+            }
+        }
         return true;
     }
 
@@ -221,10 +237,9 @@ public class HttpUser_RestClient extends TulipUser {
     /** HTTP header key value */
     public static String http_header_val = "";
 
-    /** Whether to share connections
-     * If false, then each user will be allocated its own
-     * restClient object. This is required when using
-     * httpOnly cookies to user JWTs that contain the userId.
+    /**
+     * Whether to share connections If false, then each user will be allocated its own restClient
+     * object. This is required when using httpOnly cookies to user JWTs that contain the userId.
      */
     public static boolean shareConnections = true;
 }

--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -9,23 +9,15 @@ import java.time.Duration;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
-class HttpRecord {
-    public RestClient restClient = null;
-    public HttpClient httpClient = null;
-    public String url = "";
-    public String urlProtocol = "";
-    public String urlHost = "";
-    public int urlPort = -1;
-    public String urlPath = "";
-    public String urlQuery = "";
-}
-
-record RestClientRecord(RestClient restClient, HttpClient httpClient) {
-    public RestClientRecord() {
-        this(null, null);
-    }
-}
-;
+record HttpRecord(
+        RestClient restClient,
+        HttpClient httpClient,
+        String url,
+        String urlProtocol,
+        String urlHost,
+        int urlPort,
+        String urlPath,
+        String urlQuery) {}
 
 /** The HttpUser class. */
 public class HttpUser_RestClient extends TulipUser {
@@ -64,10 +56,10 @@ public class HttpUser_RestClient extends TulipUser {
         https = new HttpRecord[urls.length];
         int idx = 0;
         for (String url : urls) {
-            https[idx] = new HttpRecord();
-            var rh = createRestClient(idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
-            https[idx].restClient = rh.restClient();
-            https[idx].httpClient = rh.httpClient();
+            https[idx] = createRestClient(idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
+            if (https[idx] == null) {
+                return false;
+            }
             idx += 1;
         }
 
@@ -91,7 +83,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @param httpVersion_
      * @return
      */
-    RestClientRecord createRestClient(
+    HttpRecord createRestClient(
             int idx,
             String url_,
             String connectTimeout_,
@@ -100,22 +92,26 @@ public class HttpUser_RestClient extends TulipUser {
 
         RestClient restClient = null;
 
-        https[idx].url = url_;
+        String urlProtocol;
+        String urlHost;
+        int urlPort;
+        String urlPath;
+        String urlQuery;
         try {
             URL url = new URI(url_).toURL();
-            https[idx].urlProtocol = url.getProtocol();
-            https[idx].urlHost = url.getHost();
-            https[idx].urlPort = url.getPort();
-            https[idx].urlPath = url.getPath();
-            https[idx].urlQuery = url.getQuery();
+            urlProtocol = url.getProtocol();
+            urlHost = url.getHost();
+            urlPort = url.getPort();
+            urlPath = url.getPath();
+            urlQuery = url.getQuery();
         } catch (Exception e) {
             e.printStackTrace();
             return null;
         }
 
-        String baseUrl = https[idx].urlProtocol + "://" + https[idx].urlHost;
-        if (https[idx].urlPort != -1) {
-            baseUrl += ":" + https[idx].urlPort;
+        String baseUrl = urlProtocol + "://" + urlHost;
+        if (urlPort != -1) {
+            baseUrl += ":" + urlPort;
         }
         logger().info("[{}]baseUrl={}", idx, baseUrl);
 
@@ -150,7 +146,15 @@ public class HttpUser_RestClient extends TulipUser {
             logger().info("[{}]readTimeoutMillis={}", idx, readTimeout_);
         }
         restClient = RestClient.builder().requestFactory(factory).baseUrl(baseUrl).build();
-        return new RestClientRecord(restClient, httpClient);
+        return new HttpRecord(
+                restClient,
+                httpClient,
+                url_,
+                urlProtocol,
+                urlHost,
+                urlPort,
+                urlPath == null ? "" : urlPath,
+                urlQuery == null ? "" : urlQuery);
     }
 
     /**
@@ -161,8 +165,8 @@ public class HttpUser_RestClient extends TulipUser {
     public boolean onStop() {
         if (shareConnections) {
             for (HttpRecord hr : https) {
-                if (hr.httpClient != null) {
-                    hr.httpClient.close();
+                if (hr.httpClient() != null) {
+                    hr.httpClient().close();
                 }
             }
         }
@@ -176,7 +180,7 @@ public class HttpUser_RestClient extends TulipUser {
      */
     public RestClient restClient() {
         if (shareConnections) {
-            return https[getUserId() % https.length].restClient;
+            return https[getUserId() % https.length].restClient();
         } else {
             throw new RuntimeException(
                     "RestClient is not shared, please create a new RestClient for each request.");
@@ -192,7 +196,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlProtocol() {
-        return https[getUserId() % https.length].urlProtocol;
+        return https[getUserId() % https.length].urlProtocol();
     }
 
     /**
@@ -201,7 +205,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlHost() {
-        return https[getUserId() % https.length].urlHost;
+        return https[getUserId() % https.length].urlHost();
     }
 
     /**
@@ -210,7 +214,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return int
      */
     public int getUrlPort() {
-        return https[getUserId() % https.length].urlPort;
+        return https[getUserId() % https.length].urlPort();
     }
 
     /**
@@ -219,7 +223,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlPath() {
-        return https[getUserId() % https.length].urlPath;
+        return https[getUserId() % https.length].urlPath();
     }
 
     /**
@@ -228,7 +232,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlQuery() {
-        return https[getUserId() % https.length].urlQuery;
+        return https[getUserId() % https.length].urlQuery();
     }
 
     /** HTTP header key name */

--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -48,6 +48,9 @@ public class HttpUser_RestClient extends TulipUser {
 
         var shareConnections_ = getUserParamValue("shareConnections");
         if (!shareConnections_.isEmpty()) {
+            if (!shareConnections_.equalsIgnoreCase("true") && !shareConnections_.equalsIgnoreCase("false")) {
+                logger().warn("Unrecognized shareConnections value '{}', defaulting to false", shareConnections_);
+            }
             shareConnections = Boolean.parseBoolean(shareConnections_);
         }
 

--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -1,11 +1,15 @@
 package io.github.tulipltt.tulip.user;
 
+import static io.github.tulipltt.tulip.core.TulipKt.gMaxNumUsers;
+
 import io.github.tulipltt.tulip.api.*;
 import io.github.tulipltt.tulip.api.TulipUser;
 import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
@@ -52,15 +56,34 @@ public class HttpUser_RestClient extends TulipUser {
             return false;
         }
 
+        int N;
         String[] urls = url_.split(",");
-        https = new HttpRecord[urls.length];
-        int idx = 0;
-        for (String url : urls) {
-            https[idx] = createRestClient(idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
-            if (https[idx] == null) {
-                return false;
+        if (shareConnections) {
+            https = new ArrayList<>(urls.length);
+            N = 1;
+        } else {
+            https = new ArrayList<>(gMaxNumUsers);
+            N = gMaxNumUsers;
+            if (urls.length > 1) {
+                logger().warn(
+                                "Multiple URLs are specified, but shareConnections is false. Only the first URL will be used.");
+                urls = Arrays.copyOf(urls, 1);
             }
-            idx += 1;
+        }
+        int n = 0;
+        int idx = 0;
+        while (n < N) {
+            for (String url : urls) {
+                HttpRecord record =
+                        createRestClient(
+                                idx, url.trim(), connectTimeout_, readTimeout_, httpVersion_);
+                if (record == null) {
+                    return false;
+                }
+                https.add(record);
+                idx += 1;
+            }
+            n += 1;
         }
 
         var httpHeader_ = getUserParamValue("httpHeader");
@@ -163,13 +186,12 @@ public class HttpUser_RestClient extends TulipUser {
      * @return boolean
      */
     public boolean onStop() {
-        if (shareConnections) {
-            for (HttpRecord hr : https) {
-                if (hr.httpClient() != null) {
-                    hr.httpClient().close();
-                }
+        for (HttpRecord hr : https) {
+            if (hr.httpClient() != null) {
+                hr.httpClient().close();
             }
         }
+        https.clear();
         return true;
     }
 
@@ -180,7 +202,7 @@ public class HttpUser_RestClient extends TulipUser {
      */
     public RestClient restClient() {
         if (shareConnections) {
-            return https[getUserId() % https.length].restClient();
+            return https.get(getUserId() % https.size()).restClient();
         } else {
             throw new RuntimeException(
                     "RestClient is not shared, please create a new RestClient for each request.");
@@ -188,7 +210,7 @@ public class HttpUser_RestClient extends TulipUser {
     }
 
     // RestClient objects
-    private static HttpRecord[] https = null;
+    private static ArrayList<HttpRecord> https = null;
 
     /**
      * getUrlProtocol() method
@@ -196,7 +218,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlProtocol() {
-        return https[getUserId() % https.length].urlProtocol();
+        return https.get(getUserId() % https.size()).urlProtocol();
     }
 
     /**
@@ -205,7 +227,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlHost() {
-        return https[getUserId() % https.length].urlHost();
+        return https.get(getUserId() % https.size()).urlHost();
     }
 
     /**
@@ -214,7 +236,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return int
      */
     public int getUrlPort() {
-        return https[getUserId() % https.length].urlPort();
+        return https.get(getUserId() % https.size()).urlPort();
     }
 
     /**
@@ -223,7 +245,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlPath() {
-        return https[getUserId() % https.length].urlPath();
+        return https.get(getUserId() % https.size()).urlPath();
     }
 
     /**
@@ -232,7 +254,7 @@ public class HttpUser_RestClient extends TulipUser {
      * @return String
      */
     public String getUrlQuery() {
-        return https[getUserId() % https.length].urlQuery();
+        return https.get(getUserId() % https.size()).urlQuery();
     }
 
     /** HTTP header key name */

--- a/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
+++ b/tulip-runtime/src/main/java/io/github/tulipltt/tulip/user/HttpUser_RestClient.java
@@ -48,8 +48,11 @@ public class HttpUser_RestClient extends TulipUser {
 
         var shareConnections_ = getUserParamValue("shareConnections");
         if (!shareConnections_.isEmpty()) {
-            if (!shareConnections_.equalsIgnoreCase("true") && !shareConnections_.equalsIgnoreCase("false")) {
-                logger().warn("Unrecognized shareConnections value '{}', defaulting to false", shareConnections_);
+            if (!shareConnections_.equalsIgnoreCase("true")
+                    && !shareConnections_.equalsIgnoreCase("false")) {
+                logger().warn(
+                                "Unrecognized shareConnections value '{}', defaulting to false",
+                                shareConnections_);
             }
             shareConnections = Boolean.parseBoolean(shareConnections_);
         }
@@ -189,12 +192,16 @@ public class HttpUser_RestClient extends TulipUser {
      * @return boolean
      */
     public boolean onStop() {
+        if (getUserId() != 0) {
+            return true;
+        }
         for (HttpRecord hr : https) {
             if (hr.httpClient() != null) {
                 hr.httpClient().close();
             }
         }
         https.clear();
+        https = null;
         return true;
     }
 

--- a/tulip-runtime/src/main/kotlin/io/github/tulipltt/tulip/core/Tulip.kt
+++ b/tulip-runtime/src/main/kotlin/io/github/tulipltt/tulip/core/Tulip.kt
@@ -95,7 +95,7 @@ val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH:mm
 var gTulipContextName: String = ""
 var gTulipContextId: Int = 0
 
-var gMaxNumUsers = 0
+@JvmField var gMaxNumUsers = 0
 var gMaxNumTasks = 0
 var gMaxNumThreads = 0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable connection-sharing option for HTTP user clients.
  * Users can enable or disable shared HTTP connections via a runtime setting.

* **Bug Fixes**
  * When sharing is disabled, the client no longer reuses shared connections and now fails fast if a shared client is requested.
  * Extra URLs beyond the first are now handled deterministically when sharing is turned off.

* **Chores**
  * Improved Java/JVM interop for the maximum user limit by exposing it as a direct JVM field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->