### PR TITLE
Fix JBang support

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -11,7 +11,7 @@ groovy=5.0.7
 gradle=9.6.1
 
 # JBang
-jbang=0.138.0
+jbang=0.139.3
 
 # Kotlin
 kotlin=2.3.21

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -11,7 +11,7 @@ groovy=5.0.7
 gradle=9.6.1
 
 # JBang
-jbang=0.139.3
+jbang=0.140.1
 
 # Kotlin
 kotlin=2.3.21

--- a/reports/update_runtime.cmd
+++ b/reports/update_runtime.cmd
@@ -1,4 +1,4 @@
-call jbang run --runtime-option -Dstdout.encoding=UTF-8 --runtime-option -Dpython.console.encoding=UTF-8 python_jvm_tulip.java --keep-java report.py
+call jbang run -R=-Dstdout.encoding=UTF-8 -R=-Dpython.console.encoding=UTF-8 python_jvm_tulip.java --keep-java report.py
 
 call jbang run FileModifier.java report_py.java
 

--- a/reports/update_runtime.sh
+++ b/reports/update_runtime.sh
@@ -1,4 +1,4 @@
-jbang run --runtime-option -Dstdout.encoding=UTF-8 --runtime-option -Dpython.console.encoding=UTF-8 python_jvm_tulip.java --keep-java report.py
+jbang run -R=-Dstdout.encoding=UTF-8 -R=-Dpython.console.encoding=UTF-8 python_jvm_tulip.java --keep-java report.py
 
 jbang run FileModifier.java report_py.java
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the JBang runtime to version 0.139.3.
  - Refined runtime option handling in report-generation scripts for improved compatibility with current JBang command syntax.
  - Preserved existing report generation and file-copying workflows while maintaining stdout and Python console encoding settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->