### PR TITLE
Update JBang to 0.141.0 adding Java 26 support

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -11,7 +11,7 @@ groovy=5.0.7
 gradle=9.6.1
 
 # JBang
-jbang=0.140.1
+jbang=0.141.0
 
 # Kotlin
 kotlin=2.3.21


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the SDKMAN JBang configuration to version 0.141.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->